### PR TITLE
Updating the template and LIP-1 to reference parameter LIPs

### DIFF
--- a/LIP-X.md
+++ b/LIP-X.md
@@ -2,7 +2,7 @@
 lip: <to be assigned>
 title: <LIP Title>
 author: <list of authors' names and/or username(s), or name(s) and email(s), e.g. (use with parentheses or triangular brackets) FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
-type: <Standard Track | Informational | Meta>
+type: <Standard Track | Parameter | Informational | Meta>
 status: Draft
 created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 discussions-to: <URL>

--- a/LIPs/LIP-1.md
+++ b/LIPs/LIP-1.md
@@ -28,7 +28,7 @@ The LIP process is a pre-processing step for proposals prior to the creation of 
 
 ### LIP Types
 
-There are three types of LIPs:
+There are four types of LIPs:
 
 - A **Standard Track LIP** describes any changes that affect the Livepeer protocol. Currently, these changes are focused around the Ethereum smart contracts and clients
 that interact with the contracts. However, in the future Standard Track LIPs may be further categorized to capture other components of the Livepeer protocol such as


### PR DESCRIPTION
The LIP-X template was missing the Parameter LIP type, and there was a miscount of the number of distinct types of LIPs in LIP-1.