### PR TITLE
docs: correct inflation calculation in LIP-100 to account for compounding

### DIFF
--- a/LIPs/LIP-100.md
+++ b/LIPs/LIP-100.md
@@ -44,15 +44,15 @@ This ensures that the inflation rate remains within the predefined bounds regard
 
 ### Proposed Parameter Values
 
-- **`inflationCeiling`**: 750,000, corresponding to ~31% per annum
+- **`inflationCeiling`**: 750,000, corresponding to ~36% per annum
 - **`inflationFloor`**: 50000, corresponding to ~2% per annum
 - **`inflationChange`**: 1000, corresponding to a doubling of the current rate of `inflationChange` up from 500.
 
-*The denominator for the above values is 1,000,000,000. A single round in Livepeer is equal to approximately 21 hours. To calculate the per annum maxmimum value for inflation, given the `inflationCeiling` for example, you would use the formula `750000/1000000000*365/(21/24)`.*
+*The denominator for the above values is 1,000,000,000. A single round in Livepeer is equal to approximately 21 hours. To calculate the per annum maximum value for inflation, given the `inflationCeiling` for example, you would use the formula `(1 + (750000 / 1e9)) ** (365 * 24 / 21) - 1`.*
 
 These values are subject to community discussion and consensus. They are also subject to community governance going forward and can be adjusted via the parameter change LIP process as needed. The rationale for setting the `inflationCeiling` to 30% per annum is that it currently is above the current inflation, meaning that this will impose a future potential ceiling to avoid runaway inflation, however it will not alter the current inflation adjustment mechanism until that value is achieved.
 
-Note, that while the above are suggested values, the community should debate these values for inclusion in the final LIP proposal. It has also been considered setting the `inflationCeiling` to something below the current rate, such as 250,000, representing 10% per annum.
+Note that while the above are suggested values, the community should debate these values for inclusion in the final LIP proposal. It has also been considered setting the `inflationCeiling` to something below the current rate, such as 250,000, representing 10% per annum.
 
 ## Rationale
 
@@ -69,7 +69,6 @@ There are currently two schools of thought on setting the initial `inflationCeil
 
 The proposed parameter values align with observed trends in similar stake-based ecosystems, balancing incentives with sustainability.
 
-
 ## Backwards Compatibility
 
 This proposal introduces new parameters to the inflation adjustment algorithm and comes with slight alterations to the existing functionality to calculate inflation. The changes are designed to be backward-compatible, from a participation perspective, ensuring seamless integration with the current protocol. However, because a new minter contract is being deployed at a new address, clients may need updates in order to read from the new Minter. Some clients may already read the latest Minter value from the controller registry on chain, in which case they may only need a restart. Though clients that have hardcoded the Minter address, will have to update.
@@ -81,7 +80,7 @@ The implementation involves:
 1. **Parameter Addition**: Introduce `inflationCeiling` and `inflationFloor` to the protocol's parameter set.
 2. **Algorithm Update**: Modify the inflation adjustment logic to incorporate the new bounds.
 3. **Parameter Adjustment**: Modify the `inflationChange` parameter to the newly proposed value of 1000.
-3. **Testing**: Conduct thorough testing to ensure the new logic functions as intended without introducing regressions.
+4. **Testing**: Conduct thorough testing to ensure the new logic functions as intended without introducing regressions.
 
 A sample implementation along with initial tests has been provided in [Pull Request #645](https://github.com/livepeer/protocol/pull/645).
 


### PR DESCRIPTION
The previous inflation formula assumed a flat annual rate and did not account for compounding, resulting in a slight error when calculating the maximum annual inflation under the 750,000 token ceiling. This update revises the documentation to reflect the correct compounding method. It also fixes some small typos in the LIP.